### PR TITLE
Get image repository and tag values from values file

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ default values below
 ```
 OpenLdap:
   Image: "docker.io/osixia/openldap"
+  ImageTag: "1.1.10"
   ImagePullPolicy: "Always"
   Component: "openldap"
 

--- a/templates/openldap.yaml
+++ b/templates/openldap.yaml
@@ -42,7 +42,7 @@ spec:
             mountPath: /config-storage
       containers:
         - name: {{.Release.Name}}
-          image: osixia/openldap:1.1.10
+          image: {{.Values.OpenLdap.Image}}:{{.Values.OpenLdap.ImageTag}}
           args: ["--loglevel", "debug"]
           volumeMounts:
             - name: config-storage

--- a/values.yaml
+++ b/values.yaml
@@ -1,5 +1,6 @@
 OpenLdap:
   Image: "docker.io/osixia/openldap"
+  ImageTag: "1.1.10"
   ImagePullPolicy: "Always"
   Component: "openldap"
 


### PR DESCRIPTION
Image repository and tag values were hardcoded in the openldap manifest template file.
Changed to get them from values file.