### PR TITLE
meaningful ldap service name

### DIFF
--- a/templates/openldap.yaml
+++ b/templates/openldap.yaml
@@ -10,26 +10,26 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app: {{.Release.Name}}
-  name: {{.Release.Name}}
+    app: {{.Release.Name}}-openldap
+  name: {{.Release.Name}}-openldap
 spec:
   ports:
     - port: 389
   selector:
-    app: {{.Release.Name}}
+    app: {{.Release.Name}}-openldap
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: {{.Release.Name}}
+  name: {{.Release.Name}}-openldap
   labels:
-    app: {{.Release.Name}}
+    app: {{.Release.Name}}-openldap
 spec:
   replicas: 1
   template:
     metadata:
       labels:
-        app: {{.Release.Name}}
+        app: {{.Release.Name}}-openldap
     spec:
       initContainers:
         - name: init-copy
@@ -42,7 +42,7 @@ spec:
           - name: config-storage
             mountPath: /config-storage
       containers:
-        - name: {{.Release.Name}}
+        - name: {{.Release.Name}}-openldap
           image: {{.Values.OpenLdap.Image}}:{{.Values.OpenLdap.ImageTag}}
           imagePullPolicy: {{.Values.OpenLdap.ImagePullPolicy}}
           args: ["--loglevel", "debug"]

--- a/templates/phpldapadmin.yaml
+++ b/templates/phpldapadmin.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{.Release.Name}}-admin
+  name: {{.Release.Name}}-ldap-admin
 spec:
 {{- if .Values.PhpLdapAdmin.NodePort }}
   type: NodePort
@@ -13,21 +13,21 @@ spec:
     nodePort: 31080
 {{- end }}
   selector:
-    app: {{.Release.Name}}-admin
+    app: {{.Release.Name}}-ldap-admin
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: {{.Release.Name}}-admin
+  name: {{.Release.Name}}-ldap-admin
 spec:
   replicas: {{.Values.OpenLdap.Replicas}}
   template:
     metadata:
       labels:
-        app: {{.Release.Name}}-admin
+        app: {{.Release.Name}}-ldap-admin
     spec:
       containers:
-      - name: {{.Release.Name}}-admin
+      - name: {{.Release.Name}}-ldap-admin
         image: {{.Values.PhpLdapAdmin.Image}}:{{.Values.PhpLdapAdmin.ImageTag}}
         imagePullPolicy: {{.Values.PhpLdapAdmin.ImagePullPolicy}}
         ports:


### PR DESCRIPTION
I want to include this chart as a subchart of my helm, naming the ldap service name as just release name is a little confusing, so want to add more meaningful suffix, thanks!